### PR TITLE
Proxy error events

### DIFF
--- a/src/direct-transport.js
+++ b/src/direct-transport.js
@@ -285,7 +285,10 @@ DirectMailer.prototype._process = function(exchange, data, callback) {
     });
 
     var sendMessage = function() {
-        connection.send(data.envelope, data.message.createReadStream(), function(err, info) {
+        var messageReadStream = data.message.createReadStream();
+        messageReadStream.on('error', this.emit.bind(this, 'error'));
+
+        connection.send(data.envelope, messageReadStream, function(err, info) {
             if (returned) {
                 return;
             }
@@ -299,7 +302,7 @@ DirectMailer.prototype._process = function(exchange, data, callback) {
             info.messageId = (data.message.getHeader('message-id') || '').replace(/[<>\s]/g, '');
             return callback(null, info);
         });
-    };
+    }.bind(this);
 
     connection.connect(function() {
         if (returned) {

--- a/test/direct-transport-test.js
+++ b/test/direct-transport-test.js
@@ -9,24 +9,7 @@ var simplesmtp = require('simplesmtp');
 chai.Assertion.includeStack = true;
 
 var PORT_NUMBER = 8712;
-
-function MockBuilder(envelope, message) {
-    this.envelope = envelope;
-    this.message = message;
-    this._headers = [];
-}
-
-MockBuilder.prototype.getEnvelope = function() {
-    return this.envelope;
-};
-
-MockBuilder.prototype.createReadStream = function() {
-    return this.message;
-};
-
-MockBuilder.prototype.getHeader = function() {
-    return 'teretere';
-};
+var MockBuilder = require('./mocks/mock-builder');
 
 describe('SMTP Transport Tests', function() {
     this.timeout(100 * 1000);

--- a/test/mocks/mock-builder.js
+++ b/test/mocks/mock-builder.js
@@ -1,0 +1,50 @@
+'use strict';
+
+var Readable = require('stream').Readable;
+var util = require('util');
+util.inherits(OneMessageStream, Readable);
+
+/**
+ * A stream which emits one 'data' event with a supplied message.
+ * @param {String} message The data to be passed to the 'data' event
+ * @param {Error} error If passed, an 'error' event is triggered with it upon reading the stream.
+ */
+function OneMessageStream(message, error) {
+    var readOnce = false;
+    Readable.call(this);
+    this._read = function(){
+        if (!readOnce) {
+            this.push(message);
+            if (error) {
+                this.emit('error', error);
+            }
+            readOnce = true;
+        } else {
+            this.push(null);
+        }
+    };
+}
+
+/**
+ * Mocks a mail builder.
+ * @param {Object} envelope Envelope object
+ * @param {String} message The message to include in the content stream
+ * @param {Error} error If passed, it's emitted asynchronously by the content stream [optional]
+ */
+function MockBuilder(envelope, message, error) {
+    this._headers = [];
+
+    this.getEnvelope = function() {
+        return envelope;
+    };
+
+    this.createReadStream = function() {
+        return new OneMessageStream(message, error);
+    };
+
+    this.getHeader = function() {
+        return 'teretere';
+    };
+}
+
+module.exports = MockBuilder;


### PR DESCRIPTION
Together with https://github.com/andris9/buildmail/pull/2, it notifies users if an error event is triggered by the content stream.
Users can then handle this error accordingly.