### PR TITLE
Populating `combinedInfo.response` when available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .DS_Store
 npm-debug.log
+.idea

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Send callback includes the following arguments
       * **info.pending[].recipients** an array of recipient addresses that are still pending
       * **info.pending[].response** Response from the SMTP server
     * **info.errors** An array of errors (for these exhanges that rejected mail)
+    * **info.response**  is a string returned by SMTP transports and includes the last SMTP response from the server
 
 ## Issues
 

--- a/lib/direct-transport.js
+++ b/lib/direct-transport.js
@@ -150,6 +150,8 @@ DirectMailer.prototype.send = function (mail, callback) {
                         combinedInfo.rejected = combinedInfo.rejected.concat(info.rejected || []);
                         combinedInfo.pending = combinedInfo.pending.concat(info.pending || []);
                         combinedInfo.messageId = info.messageId;
+                        if (info.response)
+                            combinedInfo.response = info.response;
                     }
 
                     if (returned >= domains.length) {


### PR DESCRIPTION
Hello,

I am using Haraka SMTP, and I have noticed that the callback returning `info` is not populating **info.response**: a string returned by SMTP transports and includes the last SMTP response from the server.