### PR TITLE
DirectMailer::send passes an Error object instead of a string

### DIFF
--- a/lib/direct-transport.js
+++ b/lib/direct-transport.js
@@ -84,7 +84,7 @@ DirectMailer.prototype.send = function (mail, callback) {
     envelope.to = [].concat(envelope.to || []);
 
     if (!envelope.to.length) {
-        return callback('"Recipients" addresses missing');
+        return callback(new Error('"Recipients" addresses missing'));
     }
 
     // We cant't run existing streams more than once so we need to change these


### PR DESCRIPTION
DirectMailer::send passes an Error object instead of a string
to the callback when the recipients addresses are missing.